### PR TITLE
don't require any version of ruby b/c the gem doesn't actually care

### DIFF
--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |spec|
   spec.description = 'Quickly and easily access any REST or REST-like API.'
   spec.homepage    = 'http://github.com/sendgrid/ruby-http-client'
   spec.license     = 'MIT'
-  spec.required_ruby_version = '>= 2.2'
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(/^bin/) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)


### PR DESCRIPTION
I was able to run all the tests on ruby 2.1 which is the earliest supported version of ruby without issue. The unnecessary ruby 2.2 requirement is significantly hampering our ability to adopt usage of the SendGrid API v.3.

Also see this issue that I've opened on sendgrid-ruby which is a roadblock to me running the tests for a similar change on sendgrid-ruby: https://github.com/sendgrid/sendgrid-ruby/issues/71
