### PR TITLE
return hash instead of inspect string for response headers

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -13,7 +13,7 @@ module SendGrid
     def initialize(response)
       @status_code = response.code
       @body = response.body
-      @headers = response.to_hash.inspect
+      @headers = response.to_hash
     end
   end
 


### PR DESCRIPTION
Should resolve this [issue](https://github.com/sendgrid/ruby-http-client/issues/3). Test suite passes, but was unable to run the suite for: https://github.com/sendgrid/sendgrid-ruby, though looking at how this is used in that project it seems alright.
