### PR TITLE
Ability to set the Content-Type header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin
 *.gem
 *.rbc
 /.config
@@ -28,7 +29,7 @@ build/
 
 # for a library or gem, you might want to ignore these files since the code is
 # intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
+Gemfile.lock
 # .ruby-version
 # .ruby-gemset
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ gem install ruby_http_client
 ```ruby
 require 'ruby_http_client'
 global_headers = {'Authorization' => 'Basic XXXXXXX' }
-client = SendGrid::Client(host: 'base_url', request_headers: global_headers)
+client = SendGrid::Client.new(host: 'base_url', request_headers: global_headers)
 client.your.api._(param).call.get
 puts response.status_code
 puts response.body
@@ -39,7 +39,7 @@ puts response.headers
 ```ruby
 require 'ruby_http_client'
 global_headers = {'Authorization' => 'Basic XXXXXXX' }
-client = SendGrid::Client(host: 'base_url', request_headers: global_headers)
+client = SendGrid::Client.new(host: 'base_url', request_headers: global_headers)
 query_params = { 'hello' => 0, 'world' => 1 }
 request_headers = { 'X-Test' => 'test' }
 data = { 'some' => 1, 'awesome' => 2, 'data' => 3}

--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -148,7 +148,7 @@ module SendGrid
       request = net_http.new(uri.request_uri)
       request = build_request_headers(request)
       request.body = @request_body.to_json if @request_body
-      if request.body
+      if request.body && !@request_headers.has_key?('Content-Type')
         request['Content-Type'] = 'application/json'
       elsif !request.body and (name.to_s == "post")
         request['Content-Type'] = ''

--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -147,11 +147,16 @@ module SendGrid
       net_http = Kernel.const_get('Net::HTTP::' + name.to_s.capitalize)
       request = net_http.new(uri.request_uri)
       request = build_request_headers(request)
-      request.body = @request_body.to_json if @request_body
-      if request.body && !@request_headers.has_key?('Content-Type')
+      if (@request_body &&
+          (!@request_headers.has_key?('Content-Type') ||
+           @request_headers['Content-Type'] == 'application/json')
+      )
+        request.body = @request_body.to_json
         request['Content-Type'] = 'application/json'
-      elsif !request.body and (name.to_s == "post")
+      elsif !@request_body and (name.to_s == "post")
         request['Content-Type'] = ''
+      else
+        request.body = @request_body
       end
       make_request(http, request)
     end

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -50,20 +50,20 @@ class TestClient < Minitest::Test
   def test_build_request_headers
     request = {}
     request = @client.build_request_headers(request)
-    assert_equal(@client.request_headers, request)
+    assert_equal(request, @client.request_headers)
   end
 
   def test_add_version
     url = ''
     @client.add_version(url)
-    assert_equal(url, "/#{@version}")
+    assert_equal("/#{@version}", url)
   end
 
   def test_build_query_params
     url = ''
     query_params = { 'limit' => 100, 'offset' => 0 }
     url = @client.build_query_params(url, query_params)
-    assert_equal(url, '?limit=100&offset=0')
+    assert_equal('?limit=100&offset=0', url)
   end
 
   def test_build_url
@@ -71,28 +71,28 @@ class TestClient < Minitest::Test
     params = { 'limit' => 100, 'offset' => 0 }
     url = URI.parse(@host + '/' + @version +
                     '/my/path/to/the/endpoint?limit=100&offset=0')
-    assert_equal(url1.build_url(query_params: params), url)
+    assert_equal(url, url1.build_url(query_params: params))
 
     url1 = url1.one_more
     params = { 'limit' => 100, 'offset' => 0 }
     url = URI.parse(@host + '/' + @version +
                     '/my/path/to/the/endpoint/one_more?limit=100&offset=0')
-    assert_equal(url1.build_url(query_params: params), url)
+    assert_equal(url, url1.build_url(query_params: params))
 
     url2 = @client.my.path._('to').the.endpoint
     params = { 'limit' => 100, 'offset' => 0 }
     url = URI.parse(@host + '/' + @version +
                     '/my/path/to/the/endpoint?limit=100&offset=0')
-    assert_equal(url2.build_url(query_params: params), url)
+    assert_equal(url, url2.build_url(query_params: params))
   end
 
   def test_build_request
     name = 'get'
     args = nil
     response = @client.build_request(name, args)
-    assert_equal(response.status_code, 200)
-    assert_equal(response.body, 'message' => 'success')
-    assert_equal(response.headers, 'headers' => 'test')
+    assert_equal(200, response.status_code)
+    assert_equal({'message' => 'success'}, response.body)
+    assert_equal({'headers' => 'test'}, response.headers)
   end
 
   def test_build_request_post_empty_content_type
@@ -156,19 +156,19 @@ class TestClient < Minitest::Test
     uri = URI.parse('https://localhost:4010')
     http = Net::HTTP.new(uri.host, uri.port)
     http = @client.add_ssl(http)
-    assert_equal(http.use_ssl, true)
-    assert_equal(http.verify_mode, OpenSSL::SSL::VERIFY_NONE)
+    assert_equal(true, http.use_ssl)
+    assert_equal(OpenSSL::SSL::VERIFY_NONE, http.verify_mode)
   end
 
   def test__
     url1 = @client._('test')
-    assert_equal(url1.url_path, ['test'])
+    assert_equal(['test'], url1.url_path)
   end
 
   def test_method_missing
     response = @client.get
-    assert_equal(response.status_code, 200)
-    assert_equal(response.body, 'message' => 'success')
-    assert_equal(response.headers, 'headers' => 'test')
+    assert_equal(200, response.status_code)
+    assert_equal({'message' => 'success'}, response.body)
+    assert_equal({'headers' => 'test'}, response.headers)
   end
 end

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -1,4 +1,4 @@
-require_relative '../lib/ruby_http_client'
+require 'ruby_http_client'
 require 'minitest/autorun'
 
 class MockResponse
@@ -93,6 +93,63 @@ class TestClient < Minitest::Test
     assert_equal(response.status_code, 200)
     assert_equal(response.body, 'message' => 'success')
     assert_equal(response.headers, 'headers' => 'test')
+  end
+
+  def test_build_request_post_empty_content_type
+    headers = {
+    }
+    client = MockRequest.new(
+      host: 'https://localhost',
+      request_headers: headers,
+      version: 'v3'
+    )
+    args = [{'request_body' => {"hogekey" => "hogevalue"}}]
+    client.build_request('post', args)
+    assert_equal('application/json', client.request['Content-Type'])
+    assert_equal('{"hogekey":"hogevalue"}', client.request.body)
+  end
+
+  def test_build_request_get_application_json
+    headers = {
+      'Content-Type' => 'application/json'
+    }
+    client = MockRequest.new(
+      host: 'https://localhost',
+      request_headers: headers,
+      version: 'v3'
+    )
+    client.build_request('get', nil)
+    assert_equal('application/json', client.request['Content-Type'])
+    assert_equal(nil, client.request.body)
+  end
+
+  def test_build_request_post_empty_body
+    headers = {
+      'Content-Type' => 'application/json'
+    }
+    client = MockRequest.new(
+      host: 'https://localhost',
+      request_headers: headers,
+      version: 'v3'
+    )
+    client.build_request('post', nil)
+    assert_equal('', client.request['Content-Type'])
+    assert_equal(nil, client.request.body)
+  end
+
+  def test_build_request_post_multipart
+    headers = {
+      'Content-Type' => 'multipart/form-data; boundary=xYzZY'
+    }
+    client = MockRequest.new(
+      host: 'https://localhost',
+      request_headers: headers,
+    )
+    name = 'post'
+    args = [{'request_body' => 'hogebody'}]
+    client.build_request(name, args)
+    assert_equal('multipart/form-data; boundary=xYzZY', client.request['Content-Type'])
+    assert_equal('hogebody', client.request.body)
   end
 
   def add_ssl


### PR DESCRIPTION
- This pull request is intended to add an ability to set the Content-Type header, [the python library as well](https://github.com/sendgrid/python-http-client/commit/56f6f7a1966d56ee57c128fd98ab552461d187f9).
- The trigger of this modify is making a request with except for "application/json" content-type which will be used in [inbound parse projects](https://github.com/sendgrid/sendgrid-ruby/tree/inbound). 
- Also small fix for README example
- I will send CLA soon.
