### PR TITLE
Turn on verification of TLS certificates

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -181,7 +181,7 @@ module SendGrid
       protocol = host.split(':')[0]
       if protocol == 'https'
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
       end
       http
     end

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -100,7 +100,7 @@ class TestClient < Minitest::Test
     http = Net::HTTP.new(uri.host, uri.port)
     http = @client.add_ssl(http)
     assert_equal(http.use_ssl, true)
-    assert_equal(http.verify_mode, OpenSSL::SSL::VERIFY_NONE)
+    assert_equal(http.verify_mode, OpenSSL::SSL::VERIFY_PEER)
   end
 
   def test__


### PR DESCRIPTION
Fixes https://github.com/sendgrid/ruby-http-client/issues/6.

This sets the verification mode to `VERIFY_PEER`, and instructs the underlying library to verify the peer certificates.