### PR TITLE
fix: Allow for multiple values for a parameter

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -84,7 +84,7 @@ module SendGrid
     #   - The url string with the query parameters appended
     #
     def build_query_params(url, query_params)
-      params = query_params.map { |key, value| "#{key}=#{value}" }.join('&')
+      params = URI.encode_www_form(query_params)
       url.concat("?#{params}")
     end
 

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -61,9 +61,9 @@ class TestClient < Minitest::Test
 
   def test_build_query_params
     url = ''
-    query_params = { 'limit' => 100, 'offset' => 0 }
+    query_params = { 'limit' => 100, 'offset' => 0, 'categories' => ['category1', 'category2'] }
     url = @client.build_query_params(url, query_params)
-    assert_equal('?limit=100&offset=0', url)
+    assert_equal('?limit=100&offset=0&categories=category1&categories=category2', url)
   end
 
   def test_build_url


### PR DESCRIPTION
This PR is trying to fix issue: https://github.com/sendgrid/sendgrid-ruby/issues/145

**Issue Summary**

When using the client to get statistics for categories, it's not possible to retrieve stats for all categories

**Steps to Reproduce**
```
fun_stats = sg.client.categories.stats.get(query_params: {
    'start_date' => "2017-07-31",
    'categories' => 'category1&category2'
})
```

The above code makes a GET to this URL. Sendgrid returns stats for `category1` only
```
https://api.sendgrid.com/v3/categories/stats?categories=category1&category2&start_date=2017-07-30
```

When the correct behaviour is a GET with both `category1` and `category2` as values to categories. Sendgrid returns the expected response.
```
https://api.sendgrid.com/v3/categories/stats?categories=category1&categories=category2&start_date=2017-07-30
```
This seems to be a bug, as the [Sendgrid docs](https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/categories.html#-GET-statistics) clearly state sending multiple categories is supported, and there doesn't seem to be a way to do that with this client.

**Technical details:**

sendgrid-ruby Version: 5.0.0
Ruby Version: 2.3.4
