### PR TITLE
Add a helper returns the response body as a hash

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -15,6 +15,12 @@ module SendGrid
       @body = response.body
       @headers = response.to_hash
     end
+
+    # Returns the body as a hash
+    #
+    def parsed_body
+      @parsed_body ||= JSON.parse(@body, symbolize_names: true)
+    end
   end
 
   # A simple REST client.


### PR DESCRIPTION
I think the body is already a json string, therefore I only created a method to allow it to be hash