### PR TITLE
Fix issue #13: Timeout configuration

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -135,10 +135,13 @@ module SendGrid
     # * *Returns* :
     #   - A Response object from make_request
     #
-    def build_request(name, args)
+    def build_request(name, args, read_timeout: 60, open_timeout: 60)
       build_args(args) if args
       uri = build_url(query_params: @query_params)
-      @http = add_ssl(Net::HTTP.new(uri.host, uri.port))
+      base_http = Net::HTTP.new(uri.host, uri.port)
+      base_http.read_timeout = read_timeout
+      base_http.open_timeout = open_timeout
+      @http = add_ssl(base_http)
       net_http = Kernel.const_get('Net::HTTP::' + name.to_s.capitalize)
       @request = build_request_headers(net_http.new(uri.request_uri))
       if (@request_body &&

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -160,6 +160,16 @@ class TestClient < Minitest::Test
     assert_equal(http.verify_mode, OpenSSL::SSL::VERIFY_PEER)
   end
 
+  def test_open_timeout
+    @client.build_request('post', nil, open_timeout: 2)
+    assert_equal(@client.http.open_timeout, 2)
+  end
+
+  def test_read_timeout
+    @client.build_request('post', nil, read_timeout: 2)
+    assert_equal(@client.http.read_timeout, 2)
+  end
+
   def test__
     url1 = @client._('test')
     assert_equal(['test'], url1.url_path)


### PR DESCRIPTION
**- What I did**
This PR addresses issue #13, also referenced [here](https://github.com/sendgrid/sendgrid-ruby/issues/172).

**- How I did it**
The changes include two optional arguments to the Client#build_request method, with the same default value as the ones in the Net:HTTP library. No existing code will be broken as they are optional arguments.

**-Testing**
The PR also includes tests for these new parameters.