### PR TITLE
add assert_nil to tests following deprecation warning

### DIFF
--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -120,7 +120,7 @@ class TestClient < Minitest::Test
     )
     client.build_request('get', nil)
     assert_equal('application/json', client.request['Content-Type'])
-    assert_equal(nil, client.request.body)
+    assert_nil(client.request.body)
   end
 
   def test_build_request_post_empty_body
@@ -134,7 +134,7 @@ class TestClient < Minitest::Test
     )
     client.build_request('post', nil)
     assert_equal('', client.request['Content-Type'])
-    assert_equal(nil, client.request.body)
+    assert_nil(client.request.body)
   end
 
   def test_build_request_post_multipart


### PR DESCRIPTION
When running the tests, there is a warning for the tests which use assert_equal for nil values

`DEPRECATED: Use assert_nil if expecting nil`

I added the assert_nil method in both of these cases.