### PR TITLE
feat: Add option to set http attributes when creating an instance of Client

### DIFF
--- a/examples/example.rb
+++ b/examples/example.rb
@@ -9,6 +9,12 @@ headers = JSON.parse('
 host =  'https://api.sendgrid.com'
 client = SendGrid::Client.new(host: host, request_headers: headers)
 
+# You can pass in an http_options hash to set values for NET::HTTP attributes
+# https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html
+# client = SendGrid::Client.new(host: host,
+#                               request_headers: headers,
+#                               http_options: {open_timeout: 15, read_timeout: 30})
+
 # GET Collection
 query_params = { 'limit' => 100, 'offset' => 0 }
 response = client.version('v3').api_keys.get(query_params: query_params)

--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -36,7 +36,7 @@ module SendGrid
     #                  (e.g. client._("/v3"))
     #   - +url_path+ -> A list of the url path segments
     #
-    def initialize(host: nil, request_headers: nil, version: nil, url_path: nil)
+    def initialize(host: nil, request_headers: nil, version: nil, url_path: nil, http_options: {})
       @host = host
       @request_headers = request_headers || {}
       @version = version
@@ -44,6 +44,7 @@ module SendGrid
       @methods = %w(delete get patch post put)
       @query_params = nil
       @request_body = nil
+      @http_options = http_options
     end
 
     # Update the headers for the request
@@ -152,6 +153,9 @@ module SendGrid
       else
         @request.body = @request_body
       end
+      @http_options.each do |attribute, value|
+        @http.send("#{attribute}=", value)
+      end
       make_request(@http, @request)
     end
 
@@ -198,7 +202,8 @@ module SendGrid
       url_path = name ? @url_path.push(name) : @url_path
       @url_path = []
       Client.new(host: @host, request_headers: @request_headers,
-                 version: @version, url_path: url_path)
+                 version: @version, url_path: url_path,
+                 http_options: @http_options)
     end
 
     # Dynamically add segments to the url, then call a method.

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -31,9 +31,11 @@ class TestClient < Minitest::Test
         ')
     @host = 'http://localhost:4010'
     @version = 'v3'
+    @http_options = {open_timeout: 60, read_timeout: 60}
     @client = MockRequest.new(host: @host,
                               request_headers: @headers,
-                              version: @version)
+                              version: @version,
+                              http_options: @http_options)
   end
 
   def test_init

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -34,6 +34,9 @@ class TestClient < Minitest::Test
     @http_options = {open_timeout: 60, read_timeout: 60}
     @client = MockRequest.new(host: @host,
                               request_headers: @headers,
+                              version: @version)
+    @client_with_options = MockRequest.new(host: @host,
+                              request_headers: @headers,
                               version: @version,
                               http_options: @http_options)
   end
@@ -172,5 +175,12 @@ class TestClient < Minitest::Test
     assert_equal(200, response.status_code)
     assert_equal({'message' => 'success'}, response.body)
     assert_equal({'headers' => 'test'}, response.headers)
+  end
+
+  def test_http_options
+    url1 = @client_with_options._('test')
+    assert_equal(@host, @client_with_options.host)
+    assert_equal(@headers, @client_with_options.request_headers)
+    assert_equal(['test'], url1.url_path)
   end
 end


### PR DESCRIPTION
This PR is addressing issue [#13](https://github.com/sendgrid/ruby-http-client/issues/13)

**The Problem**
The issue requests the ability to override the Net::HTTP defaults for open and read timeouts.

**What I did**
I added a parameter called http_options to the Sendgrid::Client class. This parameter should be a hash with key/value pairs corresponding with attributes for NET:HTTP as described [here](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html). I added this in the test file and added this to the example file as well. 
