### PR TITLE
Add TROUBLESHOOTING.md

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -5,11 +5,12 @@ If you can't find a solution below, please open an [issue](https://github.com/se
 ## Table of Contents
 * [Viewing the Request Body](#request-body)
 
+<a name="request-body"></a>
 ## Viewing the Request Body
 
 When debugging or testing, it may be useful to exampine the raw request body to compare against the [documented format](https://sendgrid.com/docs/API_Reference/api_v3.html).
 
-You can do this right before you call: `response = response = client.version('v3').api_keys.post(request_body: request_body)` like so:
+You can do this right before you call: `response = client.version('v3').api_keys.post(request_body: request_body)` like so:
 
 ```ruby
 puts request_body

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,16 @@
+If you have a non-library SendGrid issue, please contact our [support team](https://support.sendgrid.com).
+
+If you can't find a solution below, please open an [issue](https://github.com/sendgrid/ruby-http-client/issues).
+
+## Table of Contents
+* [Viewing the Request Body](#request-body)
+
+## Viewing the Request Body
+
+When debugging or testing, it may be useful to exampine the raw request body to compare against the [documented format](https://sendgrid.com/docs/API_Reference/api_v3.html).
+
+You can do this right before you call: `response = response = client.version('v3').api_keys.post(request_body: request_body)` like so:
+
+```ruby
+puts request_body
+```


### PR DESCRIPTION
Adding TROUBLESHOOTING.md to the project and adding a snippet about viewing the request_body before sending to SG API.

#22