### PR TITLE
Add .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,20 @@
+---
+engines:
+  duplication:
+    enabled: false
+    config:
+      languages:
+        - ruby
+  fixme:
+    enabled: false
+  phpmd:
+    enabled: false
+  radon:
+    enabled: false
+  rubocop:
+    enabled: true
+    channel: rubocop-0-48
+ratings:
+  paths:
+    - "**.rb"
+exclude_paths:


### PR DESCRIPTION
Issue https://github.com/sendgrid/ruby-http-client/issues/42

## Feature 

Add codeclimate

## Installation

- If you haven't already, install the [Code Climate CLI](https://github.com/codeclimate/codeclimate).
- Run `codeclimate engines:enable rubocop` 
This command both installs the engine and enables it in your `.codeclimate.yml`
- You're ready to analyze! 
Browse into your project's folder and run `codeclimate analyze`
- Specific language test, for instance, ruby
 run `codeclimate analyze -e robucop`


## Demo

![test2](https://user-images.githubusercontent.com/6240395/32132697-fe222faa-bb8d-11e7-8439-6d9e23c9a484.gif)


