### PR TITLE
Don't parse JSON if @body is nil

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -19,6 +19,7 @@ module SendGrid
     # Returns the body as a hash
     #
     def parsed_body
+      return @body if !@body
       @parsed_body ||= JSON.parse(@body, symbolize_names: true)
     end
   end


### PR DESCRIPTION
If there is a case where @body is a value that is not nil but also cannot be parsed, this will not be enough to avoid a throw.

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!

Issue not raised: When doing the example, it failed and request/body was `nil`, calling `parsed_body` threw an exception.
As this is not a change in functionality except in cases of expecting a throw, a simple fix seemed more effective.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
  - *If a test is necessary, please suggest it's structure and I will work to create it*
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- When @body is nil, simply avoids JSON parsing it, and returns nil
