### PR TITLE
feat: Add ability to set proxy

### DIFF
--- a/examples/example.rb
+++ b/examples/example.rb
@@ -15,6 +15,19 @@ client = SendGrid::Client.new(host: host, request_headers: headers)
 #                               request_headers: headers,
 #                               http_options: {open_timeout: 15, read_timeout: 30})
 
+# If you want to make request via proxy, you can set your proxy server in two ways.
+#
+# (1) Pass proxy_options hash
+#
+# client = SendGrid::Client.new(host: host,
+#                               request_headers: headers,
+#                               proxy_options: { host: '127.0.0.1', port: 8080 })
+#
+# (2) Set 'http_proxy' environment variable
+#
+# ENV['http_proxy'] = 'user:pass@127.0.0.1:8080'
+# client = SendGrid::Client.new(host: host, request_headers: headers)
+
 # GET Collection
 query_params = { 'limit' => 100, 'offset' => 0 }
 response = client.version('v3').api_keys.get(query_params: query_params)

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -185,6 +185,38 @@ class TestClient < Minitest::Test
     assert_equal(['test'], url1.url_path)
   end
 
+  def test_proxy_options
+    proxy_options = {
+      host: '127.0.0.1', port: 8080, user: 'anonymous', pass: 'secret'
+    }
+    client = MockRequest.new(
+      host: 'https://api.sendgrid.com',
+      request_headers: { 'Authorization' => 'Bearer xxx' },
+      proxy_options: proxy_options
+    ).version('v3').api_keys
+
+    assert(client.proxy_address, '127.0.0.1')
+    assert(client.proxy_pass, 'secret')
+    assert(client.proxy_port, 8080)
+    assert(client.proxy_user, 'anonymous')
+  end
+
+  def test_proxy_from_http_proxy_environment_variable
+    ENV['http_proxy'] = 'anonymous:secret@127.0.0.1:8080'
+
+    client = MockRequest.new(
+      host: 'https://api.sendgrid.com',
+      request_headers: { 'Authorization' => 'Bearer xxx' }
+    ).version('v3').api_keys
+
+    assert(client.proxy_address, '127.0.0.1')
+    assert(client.proxy_pass, 'secret')
+    assert(client.proxy_port, 8080)
+    assert(client.proxy_user, 'anonymous')
+  ensure
+    ENV.delete('http_proxy')
+  end
+
   def test_docker_exists
     assert(File.file?('./Dockerfile') || File.file?('./docker/Dockerfile'))
   end


### PR DESCRIPTION
# Fixes #70

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate ~~.md~~ example file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- This PR should add ability to set proxy when initializing `Sendgrid::Client`.

### Sample

```ruby
host = 'https://example.com'
headers = { 'Authorization' => 'Bearer xxx' }
proxy_options = { host: 'localhost', port: 8080, user: 'anonymous', pass: 'secret' }
client = SendGrid::Client.new(host: host, request_headers: headers, proxy_options: proxy_options }
res = client.version('v3').get
```