### PR TITLE
Add changelog generator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'rake/testtask'
+require 'github_changelog_generator/task'
 
 Rake::TestTask.new do |t|
   t.libs << 'test'
@@ -28,4 +29,11 @@ namespace :test do
     Rake::Task['rubocop'].invoke
     Rake::Task['minitest'].invoke
   end
+end
+
+desc 'Generate changelog'
+GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+  config.user = 'sendgrid'
+  config.project = 'ruby-http-client'
+  config.unreleased = false
 end

--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'github_changelog_generator'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
This PR creates a rake task to automate generation of CHANGELOG.md using `rake changelog` before releasing.
A sample of current changelog converted to new format can be seen [here](https://gist.github.com/douglaslise/03af34a45cd6b6f3f558e75b5a3fbbfb).
Resolves #87 
