### PR TITLE
Resolves #87 Automate changelog update

### DIFF
--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'git', '~> 1.5.0'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'byebug'
 end

--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'git', '~> 1.5.0'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'byebug'
 end

--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |spec|
   spec.test_files = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'git', '~> 1.5.0'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'git', '~> 1.5.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -1,14 +1,24 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
-
-require 'bundler'
-require 'bundler/setup'
-
-require 'byebug'
 require 'git'
 require 'net/http'
 require 'json'
+require 'date'
+
+def extract_pull_request_number(commit)
+  commit.message.match('Merge pull request #(\d+) from.*').captures.first
+end
+
+def fetch_pull_request_data(pull_request_number)
+  pull_request = fetch_github_data("https://api.github.com/repos/sendgrid/ruby-http-client/pulls/#{pull_request_number}")
+  user_data = fetch_github_data(pull_request['user']['url'])
+
+  { number: pull_request['number'],
+    title: pull_request['title'],
+    user_url: user_data['url'],
+    user_login: user_data['login'],
+    user_name: user_data['name'] }
+end
 
 def fetch_github_data(pull_request_url)
   uri = URI(pull_request_url)
@@ -18,27 +28,42 @@ def fetch_github_data(pull_request_url)
 
     http.request(req)
   end
+  raise("Response error #{pull_request_response.msg}") unless pull_request_response.is_a?(Net::HTTPSuccess)
   JSON.parse(pull_request_response.body)
 end
 
+def update_changelog(file_path, prs, version_number)
+  prs_entries = prs.map(&method(:changelog_entry))
+  version_header = "## [#{version_number}] - #{Date.today} \n### Added\n"
+
+  replace(file_path, /^##/) { |match| "#{version_header + prs_entries.join("\n")}\n\n#{match}" }
+end
+
+def changelog_entry(pr_data)
+  <<-ENTRY.strip
+- ##{pr_data[:number]} #{pr_data[:title]}
+- Thanks to [#{pr_data[:user_name] || pr_data[:user_login]}](#{pr_data[:user_url]}) for the pull request!\n
+  ENTRY
+end
+
+def replace(file_path, regexp, *args, &block)
+  content = File.read(file_path).sub(regexp, *args, &block)
+  File.open(file_path, 'wb') { |file| file.write(content) }
+end
+
+version_number = ARGV[0] || raise('No version number was passed')
 root_folder = File.expand_path('..', __dir__)
 g = Git.open(root_folder)
+file_path = 'CHANGELOG.md'
 
 last_tag = g.describe(nil, tags: true, abbrev: 0)
 
 merged_pull_requests = g.log.between(last_tag, 'master').grep('Merge pull request')
 
-prs = merged_pull_requests.take(2).map do |commit|
-  pull_request_id = commit.message.match('Merge pull request #(\d+) from.*').captures.first
-  pull_request = fetch_github_data("https://api.github.com/repos/sendgrid/ruby-http-client/pulls/#{pull_request_id}")
-  user_data = fetch_github_data(pull_request['user']['url'])
+prs = merged_pull_requests
+        .map(&method(:extract_pull_request_number))
+        .map(&method(:fetch_pull_request_data))
 
-  { pr_number:  pull_request['number'],
-    pr_title:   pull_request['title'],
-    user_login: user_data['login'],
-    user_url:   user_data['url'],
-    user_name:  user_data['name'] }
-end
+update_changelog(file_path, prs, version_number)
 
-byebug
-puts 'Exit'
+puts "Changelog updated, the new version is #{version_number}"

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -7,13 +7,38 @@ require 'bundler/setup'
 
 require 'byebug'
 require 'git'
+require 'net/http'
+require 'json'
+
+def fetch_github_data(pull_request_url)
+  uri = URI(pull_request_url)
+  pull_request_response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+    req = Net::HTTP::Get.new(uri)
+    req['Accept'] = 'application/vnd.github.v3+json'
+
+    http.request(req)
+  end
+  JSON.parse(pull_request_response.body)
+end
 
 root_folder = File.expand_path('..', __dir__)
 g = Git.open(root_folder)
 
-last_tag = g.describe(nil, {tags: true, abbrev: 0})
+last_tag = g.describe(nil, tags: true, abbrev: 0)
 
-merged_pull_requests = g.log.between(last_tag, 'master').grep("Merge pull request")
+merged_pull_requests = g.log.between(last_tag, 'master').grep('Merge pull request')
+
+prs = merged_pull_requests.take(2).map do |commit|
+  pull_request_id = commit.message.match('Merge pull request #(\d+) from.*').captures.first
+  pull_request = fetch_github_data("https://api.github.com/repos/sendgrid/ruby-http-client/pulls/#{pull_request_id}")
+  user_data = fetch_github_data(pull_request['user']['url'])
+
+  { pr_number:  pull_request['number'],
+    pr_title:   pull_request['title'],
+    user_login: user_data['login'],
+    user_url:   user_data['url'],
+    user_name:  user_data['name'] }
+end
 
 byebug
 puts 'Exit'

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -29,6 +29,7 @@ def fetch_github_data(pull_request_url)
     http.request(req)
   end
   raise("Response error #{pull_request_response.msg}") unless pull_request_response.is_a?(Net::HTTPSuccess)
+
   JSON.parse(pull_request_response.body)
 end
 
@@ -40,10 +41,8 @@ def update_changelog(file_path, prs, version_number)
 end
 
 def changelog_entry(pr_data)
-  <<-ENTRY.strip
-- ##{pr_data[:number]} #{pr_data[:title]}
-- Thanks to [#{pr_data[:user_name] || pr_data[:user_login]}](#{pr_data[:user_url]}) for the pull request!\n
-  ENTRY
+  "- ##{pr_data[:number]} #{pr_data[:title]}\n" \
+  "- Thanks to [#{pr_data[:user_name] || pr_data[:user_login]}](#{pr_data[:user_url]}) for the pull request!"
 end
 
 def replace(file_path, regexp, *args, &block)
@@ -61,8 +60,8 @@ last_tag = g.describe(nil, tags: true, abbrev: 0)
 merged_pull_requests = g.log.between(last_tag, 'master').grep('Merge pull request')
 
 prs = merged_pull_requests
-        .map(&method(:extract_pull_request_number))
-        .map(&method(:fetch_pull_request_data))
+      .map(&method(:extract_pull_request_number))
+      .map(&method(:fetch_pull_request_data))
 
 update_changelog(file_path, prs, version_number)
 

--- a/scripts/release.rb
+++ b/scripts/release.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+
+require 'bundler'
+require 'bundler/setup'
+
+require 'byebug'
+require 'git'
+
+root_folder = File.expand_path('..', __dir__)
+g = Git.open(root_folder)
+
+last_tag = g.describe(nil, {tags: true, abbrev: 0})
+
+merged_pull_requests = g.log.between(last_tag, 'master').grep("Merge pull request")
+
+byebug
+puts 'Exit'


### PR DESCRIPTION
Add a ruby script that can be run from root project directory with `scripts/release.rb version_number`.
The param is the `version_number` you want to upgrade your changelog.
[Here](https://gist.github.com/Veith3n/5c2cdee6a7dd9d1a201d9e7c6fdaa020) is gist of how it looks like after generation of new version with `scripts/release.rb 3.3.2`
Resolves #87 