### PR TITLE
fix: JSON body reencoding and Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,13 +23,13 @@ Metrics/ModuleLength:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-Style/SpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
   Enabled: true
 Style/ClassAndModuleChildren:
   Enabled: false
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: true
-Style/FileName:
+Naming/FileName:
   Enabled: true
 Style/RescueModifier:
   Enabled: true
@@ -39,7 +39,7 @@ Metrics/BlockLength:
   Enabled: false
 Style/NumericLiterals:
   Enabled: false
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
   Enabled: true
   AllowForAlignment: false
   ForceEqualSignAlignment: false

--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -149,7 +149,12 @@ module SendGrid
          (!@request_headers.key?('Content-Type') ||
           @request_headers['Content-Type'] == 'application/json')
 
-        @request.body = @request_body.to_json
+        # If body is a hash, encode it; else leave it alone
+        @request.body = if @request_body.class == Hash
+                          @request_body.to_json
+                        else
+                          @request_body
+                        end
         @request['Content-Type'] = 'application/json'
       elsif !@request_body && (name.to_s == 'post')
         @request['Content-Type'] = ''


### PR DESCRIPTION
Fix JSON body reencoding
Fix Rubocop configuration

Fixes #94

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Fix issue #94 
- Fix Rubocop configuration (following Rubocop's recommendations)
- Have not created a Sendgrid account and run the examples

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
