### PR TITLE
fix: Mistake on setup http_options for Net::HTTP object when build http

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -227,7 +227,9 @@ module SendGrid
     def build_http(host, port)
       params = [host, port]
       params += @proxy_options.values_at(:host, :port, :user, :pass) unless @proxy_options.empty?
-      add_ssl(Net::HTTP.new(*params))
+      http = add_ssl(Net::HTTP.new(*params))
+      http = add_http_options(http) unless @http_options.empty?
+      http
     end
 
     # Allow for https calls
@@ -241,6 +243,20 @@ module SendGrid
       if host.start_with?('https')
         http.use_ssl = true
         http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      end
+      http
+    end
+
+    # Add others http options to http object
+    #
+    # * *Args*    :
+    #   - +http+ -> HTTP::NET object
+    # * *Returns* :
+    #   - HTTP::NET object
+    #
+    def add_http_options(http)
+      @http_options.each do |attribute, value|
+        http.send("#{attribute}=", value)
       end
       http
     end

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -253,6 +253,14 @@ class TestClient < Minitest::Test
     assert_equal(http.verify_mode, OpenSSL::SSL::VERIFY_PEER)
   end
 
+  def test_add_http_options
+    uri = URI.parse('https://localhost:4010')
+    http = Net::HTTP.new(uri.host, uri.port)
+    http = @client_with_options.add_http_options(http)
+    assert_equal(http.read_timeout, 60)
+    assert_equal(http.write_timeout, 60)
+  end
+
   def test__
     url1 = @client._('test')
     assert_equal(['test'], url1.url_path)

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -257,8 +257,8 @@ class TestClient < Minitest::Test
     uri = URI.parse('https://localhost:4010')
     http = Net::HTTP.new(uri.host, uri.port)
     http = @client_with_options.add_http_options(http)
+    assert_equal(http.open_timeout, 60)
     assert_equal(http.read_timeout, 60)
-    assert_equal(http.write_timeout, 60)
   end
 
   def test__


### PR DESCRIPTION
# Fixes #

Add http_options when setup Net:HTTP object to fix the mistake from PR #67 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/ruby-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
