### PR TITLE
fix: adds support for proxy_options when calling Client#_

### DIFF
--- a/lib/ruby_http_client.rb
+++ b/lib/ruby_http_client.rb
@@ -83,7 +83,7 @@ module SendGrid
 
   # A simple REST client.
   class Client
-    attr_reader :host, :request_headers, :url_path, :request, :http
+    attr_reader :host, :request_headers, :url_path, :request, :http, :proxy_options
     # * *Args*    :
     #   - +host+ -> Base URL for the api. (e.g. https://api.sendgrid.com)
     #   - +request_headers+ -> A hash of the headers you want applied on
@@ -275,7 +275,8 @@ module SendGrid
       url_path = name ? @url_path + [name] : @url_path
       Client.new(host: @host, request_headers: @request_headers,
                  version: @version, url_path: url_path,
-                 http_options: @http_options)
+                 http_options: @http_options,
+                 proxy_options: @proxy_options)
     end
 
     # Dynamically add segments to the url, then call a method.

--- a/test/test_ruby_http_client.rb
+++ b/test/test_ruby_http_client.rb
@@ -64,13 +64,15 @@ class TestClient < Minitest::Test
     @host = 'http://localhost:4010'
     @version = 'v3'
     @http_options = { open_timeout: 60, read_timeout: 60 }
+    @proxy_options = { host: '127.0.0.1', port: 8080, user: 'anonymous', pass: 'secret'}
     @client = MockRequest.new(host: @host,
                               request_headers: @headers,
                               version: @version)
     @client_with_options = MockRequest.new(host: @host,
                                            request_headers: @headers,
                                            version: @version,
-                                           http_options: @http_options)
+                                           http_options: @http_options,
+                                           proxy_options: @proxy_options)
   end
 
   def test_init
@@ -264,6 +266,14 @@ class TestClient < Minitest::Test
   def test__
     url1 = @client._('test')
     assert_equal(['test'], url1.url_path)
+  end
+
+  def test___with_client_with_options
+    url1 = @client_with_options._('test')
+    assert_equal(['test'], url1.url_path)
+    assert_equal(@host, url1.host)
+    assert_equal(@headers, url1.request_headers)
+    assert_equal(@proxy_options, url1.proxy_options)
   end
 
   def test_ratelimit_core


### PR DESCRIPTION
Adds proxy_options support when calling `#_` on an instance of Client. 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/ruby-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

I did not add inline documentation because this is a feature that appears to be well documented, but just missing proxy_options argument making the feature non-functional
