### PR TITLE
chore: exclude unnecessary files from gem package

### DIFF
--- a/ruby_http_client.gemspec
+++ b/ruby_http_client.gemspec
@@ -10,9 +10,8 @@ Gem::Specification.new do |spec|
   spec.description = 'Quickly and easily access any REST or REST-like API.'
   spec.homepage = 'http://github.com/sendgrid/ruby-http-client'
   spec.license = 'MIT'
-  spec.files = `git ls-files -z`.split("\x0")
+  spec.files = Dir['lib/**/*'] + ['LICENSE', 'README.md', 'CHANGELOG.md']
   spec.executables = spec.files.grep(/^bin/) { |f| File.basename(f) }
-  spec.test_files = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'codecov'


### PR DESCRIPTION
Replace git ls-files with explicit file list to avoid including test files, development configs, and build artifacts in gem.

Only include lib/ directory and essential documentation.

Also, remove test_files since it doesn’t seem to be included in gemspec attributes. ref: https://guides.rubygems.org/specification-reference/

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/ruby-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
