### PR TITLE
chore: Add latest Rubies to CI matrix

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -33,7 +33,9 @@ jobs:
       - run: make install
 
       - name: Set up linter
-        run: bundle add rubocop --version "~> 1.24.1" --group "development" --skip-install
+        run: |
+          bundle add rubocop --version "~> 1.24.1" --group "development" --skip-install
+          bundle add base64 --group "development" --skip-install
         if: ${{ matrix.ruby != '2.4' }}
 
       - run: bundle install --with development

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,10 +17,10 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'jruby-9.4', 'jruby-10.0' ]
     steps:
       - name: Checkout ruby-http-client
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout ruby-http-client
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
- Add Ruby 3.2, 3.3, 3.4 and JRuby 9.4, 10.0 to CI matrix
- Remove JRuby 9.2 from CI matrix since setup-ruby on Ubuntu 24.4 only provides builds for JRuby 9.4 and later.
- Update actions/checkout to the latest
- Fix a failing test and a lint error

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/ruby-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
